### PR TITLE
Add GitHub action to pull down GitHub Changelog RSS feed

### DIFF
--- a/.github/workflows/get-changelog.yml
+++ b/.github/workflows/get-changelog.yml
@@ -15,3 +15,10 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+
+      - name: Run GitHub Changelog Action
+        uses: ./

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # github-changelog-to-issues
+
+## GitHub Changelog Action
+
+This GitHub action uses Node.js to pull down the GitHub Changelog RSS feed and generate a report with new posts. The action can be used to keep track of new updates and changes in the GitHub Changelog.
+
+### Usage
+
+To use this action, create a workflow file (e.g., `.github/workflows/get-changelog.yml`) in your repository with the following content:
+
+```yaml
+name: Get Changelog
+
+on:
+  schedule: 
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+
+      - name: Run GitHub Changelog Action
+        uses: ./action-directory
+```
+
+This workflow runs the GitHub Changelog Action daily at midnight (UTC) and generates a report with new posts from the GitHub Changelog RSS feed.

--- a/action-directory/action.yml
+++ b/action-directory/action.yml
@@ -1,0 +1,10 @@
+name: 'GitHub Changelog Action'
+description: 'Pulls down the GitHub Changelog RSS feed and generates a report with new posts.'
+
+inputs: {}
+
+outputs: {}
+
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/action-directory/index.js
+++ b/action-directory/index.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+const xml2js = require('xml2js');
+const fs = require('fs');
+
+const GITHUB_CHANGELOG_RSS_URL = 'https://github.blog/changelog/feed/';
+
+async function fetchChangelog() {
+  try {
+    const response = await axios.get(GITHUB_CHANGELOG_RSS_URL);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+async function parseChangelog(xml) {
+  try {
+    const parser = new xml2js.Parser();
+    const result = await parser.parseStringPromise(xml);
+    return result.rss.channel[0].item;
+  } catch (error) {
+    console.error('Error parsing the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+function generateReport(posts) {
+  const report = posts.map(post => {
+    return {
+      title: post.title[0],
+      link: post.link[0],
+      pubDate: post.pubDate[0],
+      description: post.description[0]
+    };
+  });
+  return report;
+}
+
+function outputReport(report) {
+  const reportFilePath = 'changelog_report.json';
+  fs.writeFileSync(reportFilePath, JSON.stringify(report, null, 2));
+  console.log(`Report generated: ${reportFilePath}`);
+}
+
+async function main() {
+  try {
+    const xml = await fetchChangelog();
+    const posts = await parseChangelog(xml);
+    const report = generateReport(posts);
+    outputReport(report);
+  } catch (error) {
+    console.error('Error generating the changelog report:', error);
+  }
+}
+
+main();

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,10 @@
+name: 'GitHub Changelog Action'
+description: 'Pulls down the GitHub Changelog RSS feed and generates a report with new posts.'
+
+inputs: {}
+
+outputs: {}
+
+runs:
+  using: 'node12'
+  main: 'index.ts'

--- a/index.js
+++ b/index.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+const xml2js = require('xml2js');
+const fs = require('fs');
+
+const GITHUB_CHANGELOG_RSS_URL = 'https://github.blog/changelog/feed/';
+
+async function fetchChangelog() {
+  try {
+    const response = await axios.get(GITHUB_CHANGELOG_RSS_URL);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+async function parseChangelog(xml) {
+  try {
+    const parser = new xml2js.Parser();
+    const result = await parser.parseStringPromise(xml);
+    return result.rss.channel[0].item;
+  } catch (error) {
+    console.error('Error parsing the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+function generateReport(posts) {
+  const report = posts.map(post => {
+    return {
+      title: post.title[0],
+      link: post.link[0],
+      pubDate: post.pubDate[0],
+      description: post.description[0]
+    };
+  });
+  return report;
+}
+
+function outputReport(report) {
+  const reportFilePath = 'changelog_report.json';
+  fs.writeFileSync(reportFilePath, JSON.stringify(report, null, 2));
+  console.log(`Report generated: ${reportFilePath}`);
+}
+
+async function main() {
+  try {
+    const xml = await fetchChangelog();
+    const posts = await parseChangelog(xml);
+    const report = generateReport(posts);
+    outputReport(report);
+  } catch (error) {
+    console.error('Error generating the changelog report:', error);
+  }
+}
+
+main();

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+import * as xml2js from 'xml2js';
+import * as fs from 'fs';
+
+const GITHUB_CHANGELOG_RSS_URL = 'https://github.blog/changelog/feed/';
+
+async function fetchChangelog(): Promise<string> {
+  try {
+    const response = await axios.get(GITHUB_CHANGELOG_RSS_URL);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+async function parseChangelog(xml: string): Promise<any[]> {
+  try {
+    const parser = new xml2js.Parser();
+    const result = await parser.parseStringPromise(xml);
+    return result.rss.channel[0].item;
+  } catch (error) {
+    console.error('Error parsing the GitHub Changelog RSS feed:', error);
+    throw error;
+  }
+}
+
+interface Post {
+  title: string;
+  link: string;
+  pubDate: string;
+  description: string;
+}
+
+function generateReport(posts: any[]): Post[] {
+  const report = posts.map(post => {
+    return {
+      title: post.title[0],
+      link: post.link[0],
+      pubDate: post.pubDate[0],
+      description: post.description[0]
+    };
+  });
+  return report;
+}
+
+function outputReport(report: Post[]): void {
+  const reportFilePath = 'changelog_report.json';
+  fs.writeFileSync(reportFilePath, JSON.stringify(report, null, 2));
+  console.log(`Report generated: ${reportFilePath}`);
+}
+
+async function main(): Promise<void> {
+  try {
+    const xml = await fetchChangelog();
+    const posts = await parseChangelog(xml);
+    const report = generateReport(posts);
+    outputReport(report);
+  } catch (error) {
+    console.error('Error generating the changelog report:', error);
+  }
+}
+
+main();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,53 @@
+import { fetchChangelog, parseChangelog, generateReport } from '../index';
+import axios from 'axios';
+import * as xml2js from 'xml2js';
+
+jest.mock('axios');
+jest.mock('xml2js');
+
+describe('GitHub Changelog Action', () => {
+  const mockXml = '<rss><channel><item><title>Test Post</title><link>https://github.blog/test-post</link><pubDate>Mon, 01 Jan 2023 00:00:00 GMT</pubDate><description>Test description</description></item></channel></rss>';
+  const mockPosts = [
+    {
+      title: ['Test Post'],
+      link: ['https://github.blog/test-post'],
+      pubDate: ['Mon, 01 Jan 2023 00:00:00 GMT'],
+      description: ['Test description']
+    }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches the GitHub Changelog RSS feed', async () => {
+    (axios.get as jest.Mock).mockResolvedValue({ data: mockXml });
+
+    const xml = await fetchChangelog();
+
+    expect(axios.get).toHaveBeenCalledWith('https://github.blog/changelog/feed/');
+    expect(xml).toBe(mockXml);
+  });
+
+  it('parses the GitHub Changelog RSS feed', async () => {
+    (xml2js.Parser.prototype.parseStringPromise as jest.Mock).mockResolvedValue({ rss: { channel: [{ item: mockPosts }] } });
+
+    const posts = await parseChangelog(mockXml);
+
+    expect(xml2js.Parser.prototype.parseStringPromise).toHaveBeenCalledWith(mockXml);
+    expect(posts).toEqual(mockPosts);
+  });
+
+  it('generates a report with new posts', () => {
+    const report = generateReport(mockPosts);
+
+    expect(report).toEqual([
+      {
+        title: 'Test Post',
+        link: 'https://github.blog/test-post',
+        pubDate: 'Mon, 01 Jan 2023 00:00:00 GMT',
+        description: 'Test description'
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
Add a new GitHub action to pull down the GitHub Changelog RSS feed and generate a report with new posts.

* **Workflow**: Modify `.github/workflows/get-changelog.yml` to include steps for setting up Node.js and running the new GitHub Changelog Action.
* **Documentation**: Update `README.md` to include a section describing the new GitHub action, its purpose, usage, and an example workflow.
* **Action Script**: Add `index.ts` to fetch, parse, and generate a report from the GitHub Changelog RSS feed.
* **Action Metadata**: Add `action.yml` to define the metadata for the GitHub action, including name, description, inputs, outputs, and execution details.
* **Tests**: Add `test/index.test.ts` to verify the functionality of the `index.ts` script, including fetching, parsing, and generating a report from the RSS feed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abirismyname/github-changelog-to-issues/pull/1?shareId=b3d0a0f4-2349-4689-8617-02fa9e5dbf4e).