### PR TITLE
Fix the GitHub action

### DIFF
--- a/.github/workflows/get-changelog.yml
+++ b/.github/workflows/get-changelog.yml
@@ -17,8 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Set up Node.js
         uses: actions/setup-node@v2
 
       - name: Run GitHub Changelog Action
-        uses: ./
+        uses: ./action.yaml


### PR DESCRIPTION
Update GitHub action to reference `action.yaml` and add repository checkout step.

* Add a step to checkout the repository using `actions/checkout@v2`.
* Update the `uses` field to reference `./action.yaml` instead of `./`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abirismyname/github-changelog-to-issues/pull/3?shareId=d42a9abf-d617-4cc6-b06d-cc92f4e102d6).